### PR TITLE
Make HWAddress hashable

### DIFF
--- a/macaddress.py
+++ b/macaddress.py
@@ -187,6 +187,10 @@ class HWAddress:
         this, that = _aligned_address_integers(self, other)
         return this > that or (this == that and self.size >= other.size)
 
+    def __hash__(self):
+        """Hash by address's raw integer value and class name"""
+        return hash((self._address, self.__class__.__name__))
+
 
 def _aligned_address_integers(address1, address2):
     size1 = address1.size


### PR DESCRIPTION
I only implemented `__hash__` method to make `HWAddress` and its subclasses hashable. This comes from my need of adding `MAC` to a `set`.